### PR TITLE
Ignore editor/OS files and the CodeGraph index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 build
+
+# OS / editor
+.DS_Store
+.vscode/
+
+# CodeGraph index
+.codegraph/


### PR DESCRIPTION
Adds `.DS_Store`, `.vscode/`, and `.codegraph/` to `.gitignore` so local editor and indexing artefacts stop showing up as untracked noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)