### PR TITLE
Write repaired-surface artifact next to the output, not the input

### DIFF
--- a/src/MultiCompMesher.cpp
+++ b/src/MultiCompMesher.cpp
@@ -43,6 +43,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <boost/program_options.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <map>
@@ -505,10 +506,19 @@ int main(int argc, char *argv[]) {
         mesh_repaired = true;
       }
       if (mesh_repaired) {
-        std::string repaired_filename(boundary_files[i]);
-        append_str_before_suffix(repaired_filename, "_repaired");
-        CGAL::IO::write_polygon_mesh(repaired_filename, surface_meshes[i]);
-        std::cout << "Repaired mesh has been saved to " << repaired_filename << ".\n";
+        // Save the repaired surface next to the OUTPUT, not into the input
+        // directory. The repaired mesh is already loaded in surface_meshes[i]
+        // and used directly; this file is only a diagnostic copy. Writing it
+        // beside the input mutated the user's boundary directory and, worse,
+        // left a *_repaired.off that a re-run re-ingested as a duplicate
+        // boundary -- the duplicate then "intersects" its original and aborts.
+        std::filesystem::path repaired =
+            std::filesystem::path(output_file).parent_path() /
+            (std::filesystem::path(boundary_files[i]).stem().string() +
+             "_repaired.off");
+        CGAL::IO::write_polygon_mesh(repaired.string(), surface_meshes[i]);
+        std::cout << "Repaired mesh has been saved to " << repaired.string()
+                  << ".\n";
       }
     }
 


### PR DESCRIPTION
## Problem

When a boundary surface needs repair/triangulation on load, the repaired mesh was also written as a diagnostic `<input>_repaired.off` **next to the input file**. This mutates the caller's input directory, and the stray `_repaired.off` is easily re-ingested as a duplicate boundary on a later run — it then self-intersects its original and meshing aborts. (Surfaced via the STEPSMeshPipeline wrapper, where re-runs failed with `X.off intersects X_repaired.off`.)

The written file is purely diagnostic: the repaired surface is already held in `surface_meshes[i]` and used directly; it is never re-read.

## Fix

Write the artifact next to the **output** mesh instead — `output_dir / (input_stem + "_repaired.off")` via `std::filesystem`. The input directory is left untouched, so nothing pollutes it and there is no stray file to re-ingest.

## Verification

Rebuilt and run via the pipeline on a fresh input dir, twice on the same dir: the input directory stays pristine, the `_repaired.off` lands next to the output, and `Detecting intersection...No intersection found` (no duplicate boundary). Builds clean (C++17, `<filesystem>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)